### PR TITLE
Action Key Error Fix

### DIFF
--- a/odoolib/main.py
+++ b/odoolib/main.py
@@ -118,8 +118,7 @@ def json_rpc(url, fct_name, params):
     result = result_req.json()
     if result.get("error", None):
         raise JsonRPCException(result["error"])
-    result["result"] = result.get("result", None)
-    return result["result"]
+    return result.get("result", None)
 
 class JsonRPCConnector(Connector):
     """

--- a/odoolib/main.py
+++ b/odoolib/main.py
@@ -6,16 +6,16 @@
 # Copyright (C) 2011 OpenERP s.a. (<http://openerp.com>)
 # Copyright (C) 2018 Odoo s.a. (<http://odoo.com>).
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met: 
-# 
+# modification, are permitted provided that the following conditions are met:
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
-# list of conditions and the following disclaimer. 
+# list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 # this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution. 
-# 
+# and/or other materials provided with the distribution.
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,7 +26,7 @@
 # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ##############################################################################
 
 """
@@ -71,7 +71,7 @@ class XmlRPCConnector(Connector):
     A type of connector that uses the XMLRPC protocol.
     """
     PROTOCOL = 'xmlrpc'
-    
+
     __logger = _getChildLogger(_logger, 'connector.xmlrpc')
 
     def __init__(self, hostname, port=8069):
@@ -118,6 +118,7 @@ def json_rpc(url, fct_name, params):
     result = result_req.json()
     if result.get("error", None):
         raise JsonRPCException(result["error"])
+    result["result"] = result.get("result", None)
     return result["result"]
 
 class JsonRPCConnector(Connector):
@@ -125,7 +126,7 @@ class JsonRPCConnector(Connector):
     A type of connector that uses the JsonRPC protocol.
     """
     PROTOCOL = 'jsonrpc'
-    
+
     __logger = _getChildLogger(_logger, 'connector.jsonrpc')
 
     def __init__(self, hostname, port=8069):
@@ -144,7 +145,7 @@ class JsonRPCSConnector(Connector):
     A type of connector that uses the JsonRPC protocol.
     """
     PROTOCOL = 'jsonrpcs'
-    
+
     __logger = _getChildLogger(_logger, 'connector.jsonrpc')
 
     def __init__(self, hostname, port=8069):
@@ -170,7 +171,7 @@ class Service(object):
         self.connector = connector
         self.service_name = service_name
         self.__logger = _getChildLogger(_getChildLogger(_logger, 'service'),service_name or "")
-        
+
     def __getattr__(self, method):
         """
         :param method: The name of the method to execute on the service.
@@ -228,7 +229,7 @@ class Connection(object):
         self.database, self.login, self.password = database, login, password
 
         self.user_id = user_id
-        
+
     def check_login(self, force=True):
         """
         Checks that the login information is valid. Throws an AuthenticationError if the
@@ -239,7 +240,7 @@ class Connection(object):
         """
         if self.user_id and not force:
             return
-        
+
         if not self.database or not self.login or self.password is None:
             raise AuthenticationError("Credentials not provided")
 
@@ -248,7 +249,7 @@ class Connection(object):
         if not self.user_id:
             raise AuthenticationError("Authentication failure")
         self.__logger.debug("Authenticated with user id %s", self.user_id)
-        
+
     def get_user_context(self):
         """
         Query the default context of the user.
@@ -256,7 +257,7 @@ class Connection(object):
         if not self.user_context:
             self.user_context = self.get_model('res.users').context_get()
         return self.user_context
-    
+
     def get_model(self, model_name):
         """
         Returns a Model instance to allow easy remote manipulation of an Odoo model.
@@ -384,4 +385,3 @@ def get_connection(hostname=None, protocol="xmlrpc", port='auto', database=None,
     already know it, in most cases you don't need to specify it.
     """
     return Connection(get_connector(hostname, protocol, port), database, login, password, user_id)
-        


### PR DESCRIPTION
Some actions in odoo do not return a result key. For example the action_validate in the stock.inventory model. This causes a key error when result["result"] is returned. The line I added will assign a value of None to the result key when the result key does not exist. This fixes the key error.