### PR TITLE
fix: add missing timeout to json_rpc httpx.post() call

### DIFF
--- a/odoolib/tools.py
+++ b/odoolib/tools.py
@@ -2,6 +2,8 @@ import httpx
 import logging
 import random
 
+DEFAULT_TIMEOUT = 60
+
 
 def _getChildLogger(logger, subname):
     return logging.getLogger(logger.name + "." + subname)
@@ -15,7 +17,7 @@ def json_rpc(url, fct_name, params, cookies={}):
     }
     result_req = httpx.post(url, json=data, cookies=cookies, headers={
         "Content-Type":"application/json",
-    })
+    }, timeout=DEFAULT_TIMEOUT)
     result = result_req.json()
     if result.get("error", None):
         raise JsonRPCException(result["error"])


### PR DESCRIPTION
tools.json_rpc() calls httpx.post() without a timeout parameter, causing it to use httpx's default of 5s. This makes jsonrpc/jsonrpcs connections fail on slow or cold-starting Odoo instances.

json2.py already has DEFAULT_TIMEOUT = 60 and passes it to all httpx calls. This mirrors that pattern in tools.py for consistency.